### PR TITLE
Replace connect with no folder static text

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -8,5 +8,7 @@ const enum Resources {
   Configuration_SelectOrganization = "Select an organization...",
   Configuration_RemovedOrganization = "Removed Azure Boards organization.",
   Configuration_SelectProject = "Select project...",
-  Configuration_LoadingProjects = "Loading projects..."
+  Configuration_LoadingProjects = "Loading projects...",
+  Configuration_ClickToConnect = "Click here to connect to Azure Boards",
+  Configuration_NoOpenFolder = "You have not yet opened a folder."
 }

--- a/src/views/workitems/workitem.tree.ts
+++ b/src/views/workitems/workitem.tree.ts
@@ -19,6 +19,10 @@ export class WorkItemTreeNodeProvider
     element?: TreeNodeParent | undefined
   ): vscode.ProviderResult<TreeNodeParent[]> {
     if (!element) {
+      if (!vscode.workspace.workspaceFolders) {
+        return [new NoOpenFolderNode()];
+      }
+
       if (!getCurrentOrganization()) {
         return [new NoConnectionNode()];
       }
@@ -60,9 +64,18 @@ export class TreeNodeParent extends vscode.TreeItem {
   }
 }
 
+class NoOpenFolderNode extends TreeNodeParent {
+  constructor() {
+    super(Resources.Configuration_NoOpenFolder);
+
+    this.contextValue = "no-folder";
+    this.iconPath = undefined;
+  }
+}
+
 class NoConnectionNode extends TreeNodeParent {
   constructor() {
-    super("Click here to connect to Azure Boards");
+    super(Resources.Configuration_ClickToConnect);
 
     this.contextValue = "no-connection";
     this.iconPath = undefined;


### PR DESCRIPTION
If there is no open folder for the work space, show a static text as such. We need a working folder tree to retrieve current org and current proj from settings.

Same solution as https://github.com/microsoft/vscode-pull-request-github/blob/ce6bc9a5214bcd611a91f29328beb9d053334630/src/view/prsTreeDataProvider.ts#L74

Fixes #62

![image](https://user-images.githubusercontent.com/19493383/58365433-1f226080-7e79-11e9-9d37-2da8919dc814.png)
